### PR TITLE
Add nesting-roast-half-aggregation-adaptor-signatures review to chaincode-labs/chaincode-podcast

### DIFF
--- a/chaincode-labs/chaincode-podcast/nesting-roast-half-aggregation-adaptor-signatures.md
+++ b/chaincode-labs/chaincode-podcast/nesting-roast-half-aggregation-adaptor-signatures.md
@@ -1,11 +1,15 @@
 ---
-title: "Nesting, ROAST, Half-Aggregation, Adaptor Signatures"
-transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
-media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Pieter-Wuille-and-Tim-Ruffing---Nesting--ROAST--Half-Aggregation--Adaptor-Signatures-part-2-e1sdgjf
-tags: ['adaptor-signatures']
-speakers: ['Pieter Wuille', 'Tim Ruffing']
-categories: ['podcast']
-date: 2022-12-27
+title: 'Nesting, ROAST, Half-Aggregation, Adaptor Signatures'
+transcript_by: '0tuedon via review.btctranscripts.com'
+media: 'https://podcasters.spotify.com/pod/show/chaincode/episodes/Pieter-Wuille-and-Tim-Ruffing---Nesting--ROAST--Half-Aggregation--Adaptor-Signatures-part-2-e1sdgjf'
+date: '2022-12-27'
+tags:
+  - 'adaptor-signatures'
+speakers:
+  - 'Pieter Wuille'
+  - 'Tim Ruffing'
+categories:
+  - 'podcast'
 ---
 Speaker 1: 00:00:00
 


### PR DESCRIPTION
This PR adds [nesting-roast-half-aggregation-adaptor-signatures](https://podcasters.spotify.com/pod/show/chaincode/episodes/Pieter-Wuille-and-Tim-Ruffing---Nesting--ROAST--Half-Aggregation--Adaptor-Signatures-part-2-e1sdgjf) transcript review to the chaincode-labs/chaincode-podcast directory.